### PR TITLE
修正注释：smtp协议名称

### DIFF
--- a/conf/admin.yaml
+++ b/conf/admin.yaml
@@ -9,14 +9,14 @@ proxy:
   subscriptionTemplate: /subscribe/%s?type=%s&timestamp=%s&token=%s
 
 email:
-  #stmp地址
-  host:
+  #smtp地址
+  host: 
   #用户名称
-  userName:
+  userName: 
   #密码
-  password:
+  password: 
   #端口
-  port:
+  port: 
   #默认false ,邮件不支持startTls不要开启
   startTlsEnabled: false
 


### PR DESCRIPTION
修正注释：smtp协议名称；
修正属性规范：host、userName、password、port，冒号后增加空格，防止后续配置易出错问题；