### PR TITLE
更新账号信息，不需要通知v2ray-api删除账号

### DIFF
--- a/step-by-step-install.md
+++ b/step-by-step-install.md
@@ -86,7 +86,7 @@
    ```  
   按自己的情况，配置admin/proxy 配置文件,可以下载到你电脑修改后在上传`/opt/jar/`,并且保持UTF-8的编码。
   
-  1. admin.yaml 需要你手动配置(`注意 host: 127.0.0.1 ，所有参数 key: value :都有一个空格 `) ：
+  1. admin.yaml 需要你手动配置(`注意，如：host: 127.0.0.1 ，所有参数 key: value ":"后面都有一个空格 `) ：
      
             email:
               #stmp地址


### PR DESCRIPTION
### 问题：
**更新账号信息，后台报错：**

> rmProxyAccount error:UNKNOWN: v2ray.com/core/proxy/vmess/inbound: User [XXXXXXX]@qq.com not found.,{ [ACCOUNTID_JSON_STRING] }

### 原因：
未与v2ray服务器进行连接的账号，在管理员更新账号信息时通知了代理，执行了删除事件。